### PR TITLE
Bug fix for HC calculation

### DIFF
--- a/app/models/query_detail.py
+++ b/app/models/query_detail.py
@@ -249,5 +249,5 @@ class Detail:
 
 def is_between(time, time_range):
     if time_range[1] < time_range[0]:
-        return time >= time_range[0] or time <= time_range[1]
-    return time_range[0] <= time <= time_range[1]
+        return time > time_range[0] or time <= time_range[1]
+    return time_range[0] < time <= time_range[1]


### PR DESCRIPTION
In `is_between` function exclude the start date (i.e. `time_range[0]`) from the time range comparison as the `time` argument is the end date of the measured interval